### PR TITLE
There is no longer the one argument hash restriction on calling the job.

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,13 +37,11 @@ end
 
 Write the Job class and code to use it.
 
-Note: perform argument is one and it must be hash.
-
 ``` ruby
 class SampleJob < ApplicationJob
   queue_as :default
-  def perform(args)
-    puts "hello, #{args[:name]}!"
+  def perform(name, greeting='hello')
+    puts "#{greeting}, #{name}!"
   end
 end
 ```
@@ -51,7 +49,7 @@ end
 ``` ruby
 class SampleController < ApplicationController
   def job
-    SampleJob.perform_later({name: 'ken'})
+    SampleJob.perform_later('ken', 'howdy')
   end
 end
 ```

--- a/lib/activejob/google_cloud_tasks/adapter.rb
+++ b/lib/activejob/google_cloud_tasks/adapter.rb
@@ -13,7 +13,7 @@ module Activejob
 
       def enqueue(job, attributes = {})
         formatted_parent = Google::Cloud::Tasks::V2beta3::CloudTasksClient.queue_path(@project, @location, job.queue_name)
-        relative_uri = "#{Activejob::GoogleCloudTasks::Config.path}/perform?job=#{job.class.to_s}&#{job.arguments.to_param}"
+        relative_uri = "#{Activejob::GoogleCloudTasks::Config.path}/perform?job=#{job.class.to_s}&#{job.arguments.to_query('params')}"
 
         task = {
           app_engine_http_request: {

--- a/lib/activejob/google_cloud_tasks/rack.rb
+++ b/lib/activejob/google_cloud_tasks/rack.rb
@@ -1,15 +1,22 @@
 require 'rack'
 
+# Rack handler endpoint to perform the task.
+# Expects a `PATH_INFO` of /perform with a `QUERY_STRING` that
+# contains a `job` and `params` key. Where `job` is the name
+# of the handler class and `params` is a serialized string of
+# arguments for the handler.
 module Activejob
   module GoogleCloudTasks
     class Rack
       class << self
         def call(env)
           if env['PATH_INFO'].match(/^\/perform/)
-            params = Hash[URI::decode_www_form(env['QUERY_STRING'])].symbolize_keys
-            raise StandardError, "Job is not specified." unless params.has_key?(:job)
+            params = parsed_params(env['QUERY_STRING'])
+            unless params.has_key?(:job)
+              raise StandardError, "Job is not specified."
+            end
 
-            klass(params[:job]).perform_now(params)
+            klass(params[:job]).perform_now(*params[:params])
             [200, {}, ['ok']]
           else
             [404, {}, ['not found']]
@@ -21,6 +28,12 @@ module Activejob
         def klass(job)
           Kernel.const_get(job.camelize)
         end
+
+        def parsed_params(query_string)
+          params = ::Rack::Utils.parse_nested_query(query_string)
+          HashWithIndifferentAccess.new params
+        end
+
       end
     end
   end

--- a/spec/activejob/rack_spec.rb
+++ b/spec/activejob/rack_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe Activejob::GoogleCloudTasks::Rack do
     job_klass = spy('GreetJob')
     expect(app).to receive(:klass) { job_klass }
 
-    params = { job: 'GreetJob', foo: 'bar' }
+    params = { job: 'GreetJob', params: ["foo", ":)", {:prefix=>"howdy"}] }
     get '/perform', params
     expect(last_response.status).to eq(200)
-    expect(job_klass).to have_received(:perform_now).with(params)
+    expect(job_klass).to have_received(:perform_now).with(*params[:params])
   end
 
   it 'raises NameError for unknown job' do


### PR DESCRIPTION
The task is serialized with an additional `params` key.
This commit will break any unprocessed jobs in the queue.